### PR TITLE
Expose -from-string and -to-string to pod

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
  :deps
  {bb-pod-racer {:git/url "git@github.com:justone/bb-pod-racer.git"
                 :sha "7d7784a72324bf7e8ae0cca9ebc93dde24d92fb9"}
-  com.taoensso/nippy {:mvn/version "2.14.0"}
+  com.taoensso/nippy {:mvn/version "3.2.0"}
   org.clojure/tools.cli {:mvn/version "1.0.194"}}
 
  :paths ["src" "resources"]}

--- a/src/brisk/main.clj
+++ b/src/brisk/main.clj
@@ -98,7 +98,11 @@
      :pod/vars [{:var/name "freeze-to-file"
                  :var/fn #(count (nippy/freeze-to-file %1 %2))}
                 {:var/name "thaw-from-file"
-                 :var/fn nippy/thaw-from-file}]}]})
+                 :var/fn nippy/thaw-from-file}
+                {:var/name "freeze-to-string"
+                 :var/fn nippy/freeze-to-string}
+                {:var/name "thaw-from-string"
+                 :var/fn nippy/thaw-from-string}]}]})
 
 (defn -main [& args]
   (let [parsed (parse-opts args cli-options)


### PR DESCRIPTION
Being able to work with strings in babashka is quite useful, eg. for writing simple filters meant to work with stdin and stdout.

This PR extends the pod config to expose `nippy/freeze-to-string` and `nippy/thaw-from-string`.

Fixes justone/brisk#1.